### PR TITLE
Move exceptions to the main namespace

### DIFF
--- a/src/ContainerException.php
+++ b/src/ContainerException.php
@@ -3,7 +3,7 @@
  * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
  */
 
-namespace Psr\Container\Exception;
+namespace Psr\Container;
 
 /**
  * Base interface representing a generic exception in a container.

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -5,9 +5,6 @@
 
 namespace Psr\Container;
 
-use Psr\Container\Exception\ContainerException;
-use Psr\Container\Exception\NotFoundException;
-
 /**
  * Describes the interface of a container that exposes methods to read its entries.
  */

--- a/src/NotFoundException.php
+++ b/src/NotFoundException.php
@@ -3,7 +3,7 @@
  * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
  */
 
-namespace Psr\Container\Exception;
+namespace Psr\Container;
 
 /**
  * No entry was found in the container.


### PR DESCRIPTION
This is so that we are consistent with other PSRs.

As suggested by @crell in https://groups.google.com/forum/#!topic/php-fig/L8rDUwRFsOU

See also https://github.com/php-fig/fig-standards/pull/830