### PR TITLE
Add a throws annotation to has method

### DIFF
--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -31,6 +31,8 @@ interface ContainerInterface
      *
      * @param string $id Identifier of the entry to look for.
      *
+     * @throws ContainerExceptionInterface Error while checking availability for the entry.
+     *
      * @return boolean
      */
     public function has($id);


### PR DESCRIPTION
The `has` method can throw an exception implementing `ContainerExceptionInterface` (just like `get`).

This PR adds the missing @throws statement.