### PR TITLE
Copy PHPDoc comments from the specification

### DIFF
--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -15,7 +15,7 @@ interface ContainerInterface
      *
      * @param string $id Identifier of the entry to look for.
      *
-     * @throws NotFoundExceptionInterface  No entry was found for this identifier.
+     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
      * @throws ContainerExceptionInterface Error while retrieving the entry.
      *
      * @return mixed Entry.
@@ -31,7 +31,7 @@ interface ContainerInterface
      *
      * @param string $id Identifier of the entry to look for.
      *
-     * @return boolean
+     * @return bool
      */
     public function has($id);
 }


### PR DESCRIPTION
There were some differences between the PHPDoc comments of the specification and this interface which I tried to eliminate.