### PR TITLE
Fixes the link to PSR-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PSR Container
 
-This repository holds all interfaces/classes/traits related to [PSR-11](https://github.com/container-interop/fig-standards/blob/master/proposed/container.md).
+This repository holds all interfaces/classes/traits related to [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md).
 
 Note that this is not a container implementation of its own. See the specification for more details.


### PR DESCRIPTION
The link currently points to the draft and not the accepted version.