### PR TITLE
Remove license phpdoc annotation

### DIFF
--- a/src/ContainerExceptionInterface.php
+++ b/src/ContainerExceptionInterface.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace Psr\Container;
 

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace Psr\Container;
 

--- a/src/NotFoundExceptionInterface.php
+++ b/src/NotFoundExceptionInterface.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace Psr\Container;
 


### PR DESCRIPTION
For consistency with other PSRs. Not doing the inverse because it doesn't seem useful to me.