### PR TITLE
Adding type-hints and extending Throwable for exception interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.2.0"
     },
     "autoload": {
         "psr-4": {
@@ -21,7 +21,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }

--- a/src/ContainerExceptionInterface.php
+++ b/src/ContainerExceptionInterface.php
@@ -8,6 +8,6 @@ namespace Psr\Container;
 /**
  * Base interface representing a generic exception in a container.
  */
-interface ContainerExceptionInterface
+interface ContainerExceptionInterface extends \Throwable
 {
 }

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -20,7 +20,7 @@ interface ContainerInterface
      *
      * @return mixed Entry.
      */
-    public function get($id);
+    public function get(string $id);
 
     /**
      * Returns true if the container can return an entry for the given identifier.
@@ -33,5 +33,5 @@ interface ContainerInterface
      *
      * @return bool
      */
-    public function has($id);
+    public function has(string $id);
 }


### PR DESCRIPTION
Starting with PHP 7.2, [parameter type widening](http://php.net/manual/en/migration72.new-features.php) allows us to omit type-hint in implementations.

This gives us a unique opportunity: we are now able to create a `ContainerInterface` that has scalar type-hints while retaining compatibility with all implementations. Since usage of scalar type-hints is one of the most requested features of PSR-11, we can fulfill that demand.

We can do this only from PHP 7.2. This PR proposes to:

- bump package version to 1.1
- bump minimum PHP version to 7.2
- add type hints to `get` and `has`

Composer will do its job and solve dependencies by itself. If PHP < 7.2 is used, it will install psr/container 1.0.x. If PHP 7.2+ is used, it will bump the version to psr/container 1.1.x.

Users running composer with PHP 7.1 and `composer update --ignore-platform-reqs` (I know some!) will certainly have a surprise, so we might want to write a blog post somewhere explaining what to do before merging this.

As a side effect, since we now are using PHP 7, we can rewrite the `ContainerExceptionInterface` to extend `Throwable`. This is a best practice as it prevents using this interface on anything but an `Exception`.

This PR does not add a "bool" return type on `has` as this would introduce a compatibility break that is not worth bumping to a major version (this would split the PHP ecosystem in 2 and we don't want to do that).

Closes #19 
Closes #12 