### PR TITLE
Make ContainerExceptionInterface extend Throwable where it is available

### DIFF
--- a/src/ContainerExceptionInterface.php
+++ b/src/ContainerExceptionInterface.php
@@ -2,9 +2,17 @@
 
 namespace Psr\Container;
 
+use Throwable;
+
 /**
  * Base interface representing a generic exception in a container.
  */
-interface ContainerExceptionInterface
-{
+if (interface_exists(Throwable::class)) {
+    interface ContainerExceptionInterface extends Throwable
+    {
+    }
+} else {
+    interface ContainerExceptionInterface
+    {
+    }
 }


### PR DESCRIPTION
I've run into some static analysis issues because the `ContainerExceptionInterface` provides no guarantee that it's actually throwable (or catchable more specifically).

I understand making it extend `Throwable` would break BC, so I think this would be the ideal middle ground, providing the benefit of stricter typing only where it's available.