### PR TITLE
docs: Standardize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 Container interface
 ==============
 
-This repository holds all interfaces and utility code related to [PSR-11 (Container interface)][psr-link].
+This repository holds all interfaces related to [PSR-11 (Container Interface)][psr-url].
 
-Note that this is not a Container implementation of its own. It is merely abstractions that describe the components of a Container.
+Note that this is not a Container implementation of its own. It is merely abstractions that describe the components of a Dependency Injection Container.
 
-You can see the [specification][psr-link] for more details and find implementations of the specification by looking for packages providing the [psr/container][implementation-link] virtual package.
+You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
 
-[psr-link]: https://www.php-fig.org/psr/psr-11/
-[implementation-link]: https://packagist.org/providers/psr/container-implementation
+[psr-url]: https://www.php-fig.org/psr/psr-11/
+[package-url]: https://packagist.org/packages/psr/container
+[implementation-url]: https://packagist.org/providers/psr/container-implementation
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# PSR Container
+Container interface
+==============
 
-This repository holds all interfaces/classes/traits related to [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md).
+This repository holds all interfaces and utility code related to [PSR-11 (Container interface)][psr-link].
 
-Note that this is not a container implementation of its own. See the specification for more details.
+Note that this is not a Container implementation of its own. It is merely abstractions that describe the components of a Container.
+
+You can see the [specification][psr-link] for more details and find implementations of the specification by looking for packages providing the [psr/container][implementation-link] virtual package.
+
+[psr-link]: https://www.php-fig.org/psr/psr-11/
+[implementation-link]: https://packagist.org/providers/psr/container-implementation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository holds all interfaces related to [PSR-11 (Container Interface)][p
 
 Note that this is not a Container implementation of its own. It is merely abstractions that describe the components of a Dependency Injection Container.
 
-You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+The installable [package][package-url] and [implementations][implementation-url] are listed on Packagist.
 
 [psr-url]: https://www.php-fig.org/psr/psr-11/
 [package-url]: https://packagist.org/packages/psr/container


### PR DESCRIPTION
What:
Standardizes the README file providing a common language and an implementation link.

Why:
There are differences between PSR's READMEs in regarding language and the lacking of implementations references. So I've updated all READMEs using the https://github.com/php-fig/http-factory as base.