### PR TITLE
Adds parameter typehints to ContainerInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.2.0"
     },
     "autoload": {
         "psr-4": {
@@ -21,7 +21,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psr\Container;
 
 /**
@@ -17,7 +19,7 @@ interface ContainerInterface
      *
      * @return mixed Entry.
      */
-    public function get($id);
+    public function get(string $id);
 
     /**
      * Returns true if the container can return an entry for the given identifier.
@@ -30,5 +32,5 @@ interface ContainerInterface
      *
      * @return bool
      */
-    public function has($id);
+    public function has(string $id);
 }


### PR DESCRIPTION
This patch bumps the minimum supported PHP version to 7.2 and adds parameter typehints to ContainerInterface, as the first step towards adding explicit typehints based on the specification.

See https://www.php-fig.org/blog/2019/10/upgrading-psr-interfaces/