### PR TITLE
Add return type hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.2.0"
     },
     "autoload": {
         "psr-4": {
@@ -21,7 +21,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psr\Container;
 
 /**
@@ -17,7 +19,7 @@ interface ContainerInterface
      *
      * @return mixed Entry.
      */
-    public function get($id);
+    public function get(string $id);
 
     /**
      * Returns true if the container can return an entry for the given identifier.
@@ -30,5 +32,5 @@ interface ContainerInterface
      *
      * @return bool
      */
-    public function has($id);
+    public function has(string $id);
 }

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -32,5 +32,5 @@ interface ContainerInterface
      *
      * @return bool
      */
-    public function has(string $id);
+    public function has(string $id): bool;
 }


### PR DESCRIPTION
**This patch builds on #27 and requires a release of ~~2.0.0~~1.1.0 before merging.**

The patch adds a return type hint to `ContainerInterface::has()`, per the already documented specification, in preparation for a ~~v3~~v2 release. No other methods were eligible, as they specified `mixed`.

See https://www.php-fig.org/blog/2019/10/upgrading-psr-interfaces/