### PR TITLE
Removing Throwable on ContainerExceptionInterface

### DIFF
--- a/src/ContainerExceptionInterface.php
+++ b/src/ContainerExceptionInterface.php
@@ -5,6 +5,6 @@ namespace Psr\Container;
 /**
  * Base interface representing a generic exception in a container.
  */
-interface ContainerExceptionInterface extends \Throwable
+interface ContainerExceptionInterface
 {
 }


### PR DESCRIPTION
We added Throwable on ContainerExceptionInterface because we thought this would not introduce any breaking changes.
Alas, some classes implementing the ContainerExceptionInterface are already adding the Throwable interface,
and PHP won't let us add the interface twice.

This problem occurs with PHP 7.2 and PHP 7.3 only.

See #30 