### PR TITLE
Replace `container-interop/container-interop` v1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,13 @@
     "autoload": {
         "psr-4": {
             "Psr\\Container\\": "src/"
-        }
+        },
+        "files": ["src/container-interop-replacements.php"]
+    },
+    "replace": {
+        "container-interop/container-interop": "^1.2.0"
+    },
+    "conflict": {
+        "container-interop/container-interop": "<1.2.0"
     }
 }

--- a/src/container-interop-replacements.php
+++ b/src/container-interop-replacements.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psr\Container;
+
+use Interop\Container\Containerinterface as InteropContainerInterface;
+use Interop\Container\Exception\ContainerException as InteropContainerException;
+use Interop\Container\Exception\NotFoundException as InteropNotFoundException;
+
+class_alias(ContainerInterface::class, InteropContainerInterface::class);
+class_alias(ContainerExceptionInterface::class, InteropContainerException::class);
+class_alias(NotFoundExceptionInterface::class, InteropNotFoundException::class);


### PR DESCRIPTION
# NOTE

Since there is no 1.2.x branch, this PR targets 1.1.x.

# Description

With v1.2.0 `container-interop/container-interop` which was released in 02/2017, the package was abandoned. It fully complies with `psr/container`.
Replacing it while keeping BC by adding `class_alias` will help upstream projects to finally get rid of `container-interop/container-interop` dependencies.

Closes #37 